### PR TITLE
Verify station name in JSON response

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -122,6 +123,17 @@ var fetchMetadata = func(param string) ([]byte, error) {
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body for %s: %v", param, err)
+	}
+
+	// Parse the JSON response
+	var jsonResponse map[string]interface{}
+	if err := json.Unmarshal(data, &jsonResponse); err != nil {
+		return nil, fmt.Errorf("error unmarshalling JSON response for %s: %v", param, err)
+	}
+
+	// Verify the stationName field
+	if stationName, ok := jsonResponse["stationName"].(string); !ok || stationName != param {
+		return nil, fmt.Errorf("stationName mismatch: expected %s, got %s", param, stationName)
 	}
 
 	return data, nil


### PR DESCRIPTION
Fixes #5

Add verification of `stationName` in `fetchMetadata` function and update tests.

* **main.go**
  - Parse the JSON response in `fetchMetadata` function.
  - Verify the `stationName` field in the JSON response.
  - Log an error and return if the `stationName` does not match the expected station name.

* **main_test.go**
  - Add test cases to verify that the `stationName` in the response matches the expected station name for different stations in the `TestFetchMetadata` function.
  - Parse the JSON response and check the `stationName` field in the `TestFetchMetadata` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/fip-metadata-server/pull/10?shareId=ad3ed92f-1ab0-4e5d-b937-2c62228e0589).