### PR TITLE
fix: migrate to Radio France livemeta API

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -109,6 +109,10 @@ func testAllStations(t *testing.T, cfg *TestIntegrationConfig) {
 					t.Errorf("Expected field '%s' missing from response for station %s", field, station)
 				}
 			}
+
+			if name, ok := result["stationName"].(string); ok && name != station {
+				t.Errorf("stationName mismatch for %s: got %s", station, name)
+			}
 		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -20,11 +21,34 @@ type CachedResponse struct {
 	CachedAt time.Time
 }
 
+// stationConfig holds the numeric ID and API format for a FIP channel
+type stationConfig struct {
+	ID     int
+	Format string
+}
+
 var (
 	cache      = make(map[string]CachedResponse)
 	cacheMutex sync.Mutex
 	cacheTTL   = 1 * time.Second // Cache Time-To-Live
-	baseURL    = "https://www.radiofrance.fr/fip/api/live"
+	baseURL    = "https://api.radiofrance.fr/livemeta/live"
+
+	// stationMap maps channel names to their Radio France station IDs and API formats.
+	// The main FIP station uses "webrf_fip_player"; webradios use "webrf_webradio_player".
+	stationMap = map[string]stationConfig{
+		"fip":             {ID: 7, Format: "webrf_fip_player"},
+		"fip_rock":        {ID: 64, Format: "webrf_webradio_player"},
+		"fip_jazz":        {ID: 65, Format: "webrf_webradio_player"},
+		"fip_groove":      {ID: 66, Format: "webrf_webradio_player"},
+		"fip_world":       {ID: 69, Format: "webrf_webradio_player"},
+		"fip_nouveautes":  {ID: 70, Format: "webrf_webradio_player"},
+		"fip_reggae":      {ID: 71, Format: "webrf_webradio_player"},
+		"fip_electro":     {ID: 74, Format: "webrf_webradio_player"},
+		"fip_metal":       {ID: 77, Format: "webrf_webradio_player"},
+		"fip_pop":         {ID: 78, Format: "webrf_webradio_player"},
+		"fip_hiphop":      {ID: 95, Format: "webrf_webradio_player"},
+		"fip_cultes":      {ID: 709, Format: "webrf_webradio_player"},
+	}
 )
 
 func main() {
@@ -119,9 +143,22 @@ func getCachedData(param string) ([]byte, string, error) {
 
 // Make fetchMetadata a variable so it can be replaced in tests
 var fetchMetadata = func(param string) ([]byte, error) {
-	url := fmt.Sprintf("%s?webradio=%s", baseURL, param)
+	station, ok := stationMap[param]
+	if !ok {
+		return nil, fmt.Errorf("unknown station: %s", param)
+	}
+
+	url := fmt.Sprintf("%s/%d/%s", baseURL, station.ID, station.Format)
 	log.Printf("Fetching data from: %s\n", url)
-	resp, err := http.Get(url)
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for %s: %v", param, err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip, deflate")
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching data for %s: %v", param, err)
 	}
@@ -131,27 +168,40 @@ var fetchMetadata = func(param string) ([]byte, error) {
 		return nil, fmt.Errorf("received non-200 response code for %s: %d", param, resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	// Handle gzip-compressed responses
+	var reader io.Reader = resp.Body
+	if resp.Header.Get("Content-Encoding") == "gzip" {
+		gzReader, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error creating gzip reader for %s: %v", param, err)
+		}
+		defer gzReader.Close()
+		reader = gzReader
+	}
+
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body for %s: %v", param, err)
 	}
 
-	// Verify the response is not null and has the expected stationName field
 	var jsonResponse map[string]interface{}
 	if err := json.Unmarshal(data, &jsonResponse); err != nil {
 		return nil, fmt.Errorf("error unmarshalling JSON response for %s: %v", param, err)
 	}
 
-	// Check if response is null (FIP API error case)
 	if jsonResponse == nil {
 		return nil, fmt.Errorf("received null response from FIP API for %s", param)
 	}
 
-	if stationName, ok := jsonResponse["stationName"].(string); !ok || stationName != param {
-		return nil, fmt.Errorf("stationName mismatch: expected %s, got %s", param, stationName)
+	// Inject stationName for backward compatibility
+	jsonResponse["stationName"] = param
+
+	enriched, err := json.Marshal(jsonResponse)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling enriched response for %s: %v", param, err)
 	}
 
-	return data, nil
+	return enriched, nil
 }
 
 func generateETag(data []byte) string {

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,10 @@
+// ABOUTME: Unit tests for the FIP metadata server.
+// ABOUTME: Tests handler, caching, metadata fetching, and station name validation.
 package main
 
 import (
-	"bytes"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,26 +18,25 @@ type TestServer struct {
 	server *httptest.Server
 }
 
-// NewTestServer creates and returns a new test server
+// NewTestServer creates and returns a test server that mimics the Radio France livemeta API
 func NewTestServer() *TestServer {
 	ts := &TestServer{}
 	ts.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Check if the request path contains the expected endpoint
-		if r.URL.Path != "/fip/api/live" {
-			http.Error(w, "Not found", http.StatusNotFound)
-			return
-		}
-
-		// Get the webradio parameter
-		webradio := r.URL.Query().Get("webradio")
-		if webradio == "" {
-			http.Error(w, "Missing webradio parameter", http.StatusBadRequest)
-			return
-		}
-
-		// Return appropriate test response based on the webradio parameter
+		// The new API path format is /livemeta/live/{stationId}/{format}
 		w.Header().Set("Content-Type", "application/json")
-		if _, err := w.Write([]byte(`{"stationName":"` + webradio + `"}`)); err != nil {
+		resp := map[string]interface{}{
+			"now": map[string]interface{}{
+				"firstLine":  "Test Song",
+				"secondLine": "Test Artist",
+				"cover":      "test-cover-uuid",
+				"startTime":  1700000000,
+				"endTime":    1700000300,
+			},
+			"next": []interface{}{},
+			"prev": []interface{}{},
+		}
+		data, _ := json.Marshal(resp)
+		if _, err := w.Write(data); err != nil {
 			http.Error(w, "Error writing response", http.StatusInternalServerError)
 			return
 		}
@@ -53,18 +55,24 @@ func (ts *TestServer) URL() string {
 }
 
 func TestHandler(t *testing.T) {
-	// Setup test server
-	ts := NewTestServer()
-	defer ts.Close()
-
-	// Store the original URL and restore it after the test
+	// Store the original and restore it after the test
 	originalFetchMetadata := fetchMetadata
 	defer func() { fetchMetadata = originalFetchMetadata }()
 
 	// Override fetchMetadata for testing
 	fetchMetadata = func(param string) ([]byte, error) {
-		return []byte(`{"stationName":"` + param + `"}`), nil
+		resp := map[string]interface{}{
+			"stationName": param,
+			"now":         map[string]interface{}{"firstLine": "Test"},
+		}
+		data, _ := json.Marshal(resp)
+		return data, nil
 	}
+
+	// Reset cache for this test
+	cacheMutex.Lock()
+	cache = make(map[string]CachedResponse)
+	cacheMutex.Unlock()
 
 	req, err := http.NewRequest("GET", "/api/metadata/fip_rock", nil)
 	if err != nil {
@@ -80,11 +88,35 @@ func TestHandler(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v",
 			status, http.StatusOK)
 	}
+}
 
-	// Reset cache for this test
+func TestHandlerUnknownStation(t *testing.T) {
+	// Reset cache
 	cacheMutex.Lock()
 	cache = make(map[string]CachedResponse)
 	cacheMutex.Unlock()
+
+	// Restore original fetchMetadata after test
+	originalFetchMetadata := fetchMetadata
+	defer func() { fetchMetadata = originalFetchMetadata }()
+
+	// Use real fetchMetadata (it will fail on unknown station before making HTTP call)
+	fetchMetadata = originalFetchMetadata
+
+	req, err := http.NewRequest("GET", "/api/metadata/fip_nonexistent", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	router := mux.NewRouter()
+	router.HandleFunc("/api/metadata/{param}", handler)
+	router.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusInternalServerError {
+		t.Errorf("handler should return 500 for unknown station: got %v want %v",
+			status, http.StatusInternalServerError)
+	}
 }
 
 func TestGetCachedData(t *testing.T) {
@@ -94,7 +126,7 @@ func TestGetCachedData(t *testing.T) {
 	cacheMutex.Unlock()
 
 	param := "fip_rock"
-	testData := []byte(`{"stationName":"fip_rock"}`)
+	testData := []byte(`{"stationName":"fip_rock","now":{"firstLine":"Test"}}`)
 
 	// Pre-populate cache with test data
 	cacheMutex.Lock()
@@ -109,7 +141,7 @@ func TestGetCachedData(t *testing.T) {
 		t.Fatalf("getCachedData returned an error: %v", err)
 	}
 
-	if !bytes.Equal(data, testData) {
+	if string(data) != string(testData) {
 		t.Errorf("getCachedData returned unexpected data: got %v want %v",
 			string(data), string(testData))
 	}
@@ -126,21 +158,30 @@ func TestFetchMetadata(t *testing.T) {
 	ts := NewTestServer()
 	defer ts.Close()
 
-	// Store the original baseURL and restore it after the test
+	// Override baseURL to point to test server
 	originalBaseURL := baseURL
-	baseURL = ts.server.URL + "/fip/api/live" // Fixed: Using server.URL directly
+	baseURL = ts.server.URL + "/livemeta/live"
 	defer func() { baseURL = originalBaseURL }()
 
-	param := "test"
+	param := "fip_rock"
 	data, err := fetchMetadata(param)
 	if err != nil {
 		t.Fatalf("fetchMetadata returned an error: %v", err)
 	}
 
-	expectedData := []byte(`{"stationName":"test"}`)
-	if !bytes.Equal(data, expectedData) {
-		t.Errorf("fetchMetadata returned unexpected data: got %s want %s",
-			string(data), string(expectedData))
+	var resp map[string]interface{}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	// Verify stationName is injected
+	if resp["stationName"] != param {
+		t.Errorf("expected stationName %s, got %v", param, resp["stationName"])
+	}
+
+	// Verify now block exists
+	if resp["now"] == nil {
+		t.Error("expected 'now' field in response")
 	}
 }
 
@@ -156,21 +197,70 @@ func TestStationNames(t *testing.T) {
 			ts := NewTestServer()
 			defer ts.Close()
 
-			// Store the original baseURL and restore it after the test
+			// Override baseURL to point to test server
 			originalBaseURL := baseURL
-			baseURL = ts.server.URL + "/fip/api/live"
+			baseURL = ts.server.URL + "/livemeta/live"
 			defer func() { baseURL = originalBaseURL }()
 
 			data, err := fetchMetadata(station)
 			if err != nil {
-				t.Fatalf("fetchMetadata returned an error: %v", err)
+				t.Fatalf("fetchMetadata returned an error for %s: %v", station, err)
 			}
 
-			expectedData := []byte(`{"stationName":"` + station + `"}`)
-			if !bytes.Equal(data, expectedData) {
-				t.Errorf("fetchMetadata returned unexpected data for %s: got %s want %s",
-					station, string(data), string(expectedData))
+			var resp map[string]interface{}
+			if err := json.Unmarshal(data, &resp); err != nil {
+				t.Fatalf("failed to unmarshal response for %s: %v", station, err)
+			}
+
+			// Verify stationName is injected for backward compatibility
+			if resp["stationName"] != station {
+				t.Errorf("expected stationName %s, got %v", station, resp["stationName"])
 			}
 		})
+	}
+}
+
+func TestStationMap(t *testing.T) {
+	// Verify all expected stations exist in the mapping
+	expectedStations := []string{
+		"fip", "fip_rock", "fip_jazz", "fip_groove", "fip_world",
+		"fip_nouveautes", "fip_reggae", "fip_electro", "fip_metal",
+		"fip_pop", "fip_hiphop", "fip_cultes",
+	}
+
+	for _, name := range expectedStations {
+		cfg, ok := stationMap[name]
+		if !ok {
+			t.Errorf("station %s not found in stationMap", name)
+			continue
+		}
+		if cfg.ID <= 0 {
+			t.Errorf("station %s has invalid ID: %d", name, cfg.ID)
+		}
+		if cfg.Format == "" {
+			t.Errorf("station %s has empty format", name)
+		}
+	}
+
+	// Verify main FIP uses fip_player format
+	if stationMap["fip"].Format != "webrf_fip_player" {
+		t.Errorf("main FIP station should use webrf_fip_player format, got %s", stationMap["fip"].Format)
+	}
+}
+
+func TestBuildURL(t *testing.T) {
+	// Verify URL construction for a known station
+	station := stationMap["fip_rock"]
+	url := fmt.Sprintf("%s/%d/%s", baseURL, station.ID, station.Format)
+	expected := "https://api.radiofrance.fr/livemeta/live/64/webrf_webradio_player"
+	if url != expected {
+		t.Errorf("expected URL %s, got %s", expected, url)
+	}
+
+	station = stationMap["fip"]
+	url = fmt.Sprintf("%s/%d/%s", baseURL, station.ID, station.Format)
+	expected = "https://api.radiofrance.fr/livemeta/live/7/webrf_fip_player"
+	if url != expected {
+		t.Errorf("expected URL %s, got %s", expected, url)
 	}
 }


### PR DESCRIPTION
## Summary
- The upstream Radio France API (`www.radiofrance.fr/fip/api/live`) was decommissioned and returns 404 for all stations
- Migrates to the replacement API at `api.radiofrance.fr/livemeta/live/{stationId}/{format}`
- Maps all 12 FIP channel names to their numeric station IDs (including new channels: Cultes, Pop, Hip-Hop)
- Handles gzip-compressed responses and injects `stationName` for backward compatibility

## Test plan
- [x] Unit tests pass (`go test -short`)
- [x] Integration tests pass against real API (`INTEGRATION_TESTS=1 go test`)
- [x] All 12 stations return valid metadata including FIP Cultes (709)
- [ ] Verify after deploy: `curl https://fip-metadata.fly.dev/api/metadata/fip_cultes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for unknown station requests
  * Added support for gzip-compressed API responses

* **Tests**
  * Enhanced test coverage for station validation and error scenarios
  * Updated tests to align with API response format changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->